### PR TITLE
ADZ-2130 expanding list of colours / coloured tags

### DIFF
--- a/src/nhsd/components/atoms/tag/_index.scss
+++ b/src/nhsd/components/atoms/tag/_index.scss
@@ -22,6 +22,7 @@ $-root: ".nhsd-a-tag";
   font-size: .556rem;
   letter-spacing: .0555rem;
   text-transform: uppercase;
+  white-space: nowrap;
 
   .nhsd-a-icon {
     margin-bottom: 3px;
@@ -50,6 +51,18 @@ $-root: ".nhsd-a-tag";
 
   &--bg-light-green {
     background: nhsd-colours.get("green-20-tint");
+  }
+
+  &--bg-light-amber {
+    background: nhsd-colours.get("light-amber");
+  }
+
+  &--bg-light-yellow {
+    background: nhsd-colours.get("light-yellow");
+  }
+
+  &--bg-light-purple {
+    background: nhsd-colours.get("light-purple");
   }
 
   // Meta tag shorthand

--- a/src/nhsd/scss-core/tokens/_colours.scss
+++ b/src/nhsd/scss-core/tokens/_colours.scss
@@ -6,6 +6,7 @@
 // Private members
 $-root: ".nhsd-";
 $colours: (
+  "light-amber": #ffedc5,
   "dark-blue": #003087,
   "accessible-blue": #004da8,
   "blue": #005bbb,
@@ -23,9 +24,11 @@ $colours: (
   "pale-grey-80-tint": #edf1f1,
   "pale-grey-40-tint": #f6f8f8,
   "pink": #ae2573,
+  "light-purple": #dcbdfc,
   "accessible-red": #b30f0f,
   "red": #da291c,
   "orange": #fa9200,
+  "light-yellow": #fef9cc,
   "warm-yellow": #ffb81c,
   "dark-green": #006646,
   "green": #009639,


### PR DESCRIPTION
API Management require a greater range of coloured options for nhsd-a-tag components. [A separate PR](https://github.com/NHS-digital-website/hippo/pull/2210) exists in the digital website repo to implement that change; this PR exists to feed the changes back to the core design system.

Additionally, a nowrap whitespace attribute has been added to prevent any tag that contains whitespace wrapping around the screen and appearing as two (or more) distinct tags