### PR TITLE
[DW-3372] Switches out the upload-release-asset to homemade version

### DIFF
--- a/.github/actions/upload-release-asset/action.yml
+++ b/.github/actions/upload-release-asset/action.yml
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright (c) 2023 Geoffrey Hayward
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+name: Upload Release Asset
+description: Uploads a release asset to a repository using the GitHub API from the caller's working directory.
+
+inputs:
+  upload_url:
+    description: 'The GitHub release URL for uploading assets to.'
+    required: true
+  asset_path:
+    description: 'The asset to be upload.'
+    required: true
+  asset_name:
+    description: 'The name of the asset after it has been upload.'
+    required: true
+  asset_content_type:
+    description: 'The content type of the asset.'
+    default: 'application/octet-stream'
+    required: false
+
+outputs:
+  response:
+    description: "The JSON response from the GitHub API."
+    value: ${{ steps.upload_release_asset.outputs.response }}
+
+runs:
+  using: "composite"
+  steps:
+
+    # API Documentation https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset
+    - id: upload_release_asset
+      run: |
+        cd $(dirname ${{ inputs.asset_path }})
+        url=$(echo "${{ inputs.upload_url }}?name=${{ inputs.asset_name }}" | sed -e 's/{[^}]*}//')
+        response=$(curl \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Content-Type: ${{ inputs.asset_content_type }}" \
+        -X POST ${url} \
+        --data-binary "@$(basename ${{ inputs.asset_path }})")
+        echo "response=$response" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -280,9 +280,13 @@ jobs:
       # Step 4
       # Add release assets
       # - Adds dist, storybook and package to the release
-      #
+
+      # Checkout is required for the upload-release-asset action to work.
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Upload Homepage Dist Zip
-        uses: actions/upload-release-asset@v1
+        uses: ./.github/actions/upload-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -292,7 +296,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload CDN Dist Zip
-        uses: actions/upload-release-asset@v1
+        uses: ./.github/actions/upload-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -302,7 +306,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Storybook Zip
-        uses: actions/upload-release-asset@v1
+        uses: ./.github/actions/upload-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -312,7 +316,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload NPM Package Zip
-        uses: actions/upload-release-asset@v1
+        uses: ./.github/actions/upload-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Since [actions/upload-release-asset@v1](https://github.com/actions/upload-release-asset) has been archived and is stuck on node12 (now deprecated), I swapped it for a local Composite Action that uses the GitHub API via CRUL.

Future updates do the Composite Action can be found [here](https://github.com/GeoffreyHayward/upload-release-asset).