### PR TITLE
[DW-3372] Moves the checkout step to top of job

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -219,6 +219,15 @@ jobs:
     timeout-minutes: 20
 
     steps:
+
+      #
+      # Step 0
+      # Checkout is required for the upload-release-asset action to work.
+      #
+      - name: Checkout
+        uses: actions/checkout@v3
+
+
       #
       # Step 1
       #
@@ -280,10 +289,6 @@ jobs:
       # Step 4
       # Add release assets
       # - Adds dist, storybook and package to the release
-
-      # Checkout is required for the upload-release-asset action to work.
-      - name: Checkout
-        uses: actions/checkout@v3
 
       - name: Upload Homepage Dist Zip
         uses: ./.github/actions/upload-release-asset


### PR DESCRIPTION
The checkout being lower seems to delete the workflow-artifacts folder