### PR TITLE
[WSP-304] Update to artifact versions and its dependencies

### DIFF
--- a/.github/workflows/distribution-workflow.yml
+++ b/.github/workflows/distribution-workflow.yml
@@ -20,14 +20,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -51,7 +51,7 @@ jobs:
       # Store homepage distribution workflow artifacts
       #
       - name: Archive dist artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: homepage-dist
           path: homepage/dist/
@@ -70,14 +70,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -99,7 +99,7 @@ jobs:
       # Store CDN distribution workflow artifacts
       #
       - name: Archive dist artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdn-dist
           path: |
@@ -124,14 +124,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -156,7 +156,7 @@ jobs:
       # Store Storybook workflow artifacts
       #
       - name: Archive storybook artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-dist
           path: storybook-static/
@@ -176,14 +176,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -205,7 +205,7 @@ jobs:
       # Store NPM Package workflow artifacts
       #
       - name: Archive NPM package artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm-dist
           path: |
@@ -228,7 +228,7 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download CDN artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: cdn-dist
@@ -269,7 +269,7 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: storybook-dist

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -20,14 +20,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -61,14 +61,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -101,14 +101,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -141,14 +141,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,14 +19,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -50,7 +50,7 @@ jobs:
       # Store homepage distribution workflow artifacts
       #
       - name: Archive dist artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: homepage-dist
           path: homepage/dist/
@@ -69,14 +69,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -98,7 +98,7 @@ jobs:
       # Store CDN distribution workflow artifacts
       #
       - name: Archive dist artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdn-dist
           path: |
@@ -122,14 +122,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -154,7 +154,7 @@ jobs:
       # Store Storybook workflow artifacts
       #
       - name: Archive storybook artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-dist
           path: storybook-static/
@@ -173,14 +173,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -202,7 +202,7 @@ jobs:
       # Store NPM Package workflow artifacts
       #
       - name: Archive NPM package artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm-dist
           path: |
@@ -225,14 +225,14 @@ jobs:
       # Checkout is required for the upload-release-asset action to work.
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
 
       #
       # Step 1
       #
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           path: workflow-artifacts
@@ -346,7 +346,7 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download CDN artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: cdn-dist
@@ -387,7 +387,7 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: storybook-dist
@@ -428,13 +428,13 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: homepage-dist
           path: homepage-dist
       - name: Download version artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: homepage-dist
 

--- a/.github/workflows/test-distribution-workflow.yml
+++ b/.github/workflows/test-distribution-workflow.yml
@@ -52,14 +52,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -83,7 +83,7 @@ jobs:
       # Store homepage distribution workflow artifacts
       #
       - name: Archive dist artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: homepage-dist
           path: homepage/dist/
@@ -102,14 +102,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -131,7 +131,7 @@ jobs:
       # Store CDN distribution workflow artifacts
       #
       - name: Archive dist artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdn-dist
           path: |
@@ -156,14 +156,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -188,7 +188,7 @@ jobs:
       # Store Storybook workflow artifacts
       #
       - name: Archive storybook artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-dist
           path: storybook-static/
@@ -208,14 +208,14 @@ jobs:
       # Checkout the project's sourcecode
       #
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #
       # Step 2
       # Set Node.js version
       #
       - name: Request Node Version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16.19.0'
           cache: 'npm'
@@ -237,7 +237,7 @@ jobs:
       # Store NPM Package workflow artifacts
       #
       - name: Archive NPM package artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm-dist
           path: |
@@ -260,7 +260,7 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download CDN artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: cdn-dist
@@ -301,7 +301,7 @@ jobs:
       # Download CDN artifact and merge version artifact into the same folder
       #
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: storybook-dist


### PR DESCRIPTION
Updated the following deprecated version v3 references with v4 

1. actions/checkout@v3 to actions/checkout@v4
2. actions/setup-node@v3 to actions/setup-node@v4
3. actions/upload-artifact@v3 to actions/upload-artifact@v4
4. actions/download-artifact@v3 to actions/download-artifact@v4

Please review the changes made.